### PR TITLE
Changed StreamDeckAction to dynamic while invoking reflection type

### DIFF
--- a/Parithon.StreamDeck.SDK.MSBuild.Tool/Manifest.cs
+++ b/Parithon.StreamDeck.SDK.MSBuild.Tool/Manifest.cs
@@ -4,11 +4,11 @@ using Parithon.StreamDeck.SDK.Models;
 
 internal static class ReflectionExtension
 {
-  public static StreamDeckAction GetInstance(this Type type)
+  public static dynamic GetInstance(this Type type)
   {
     var ctor = type.GetConstructors().First();
     var parameters = ctor.GetParameters().Select(p => p.ParameterType.GetInstance()).ToArray();
-    return ctor.Invoke(parameters) as StreamDeckAction;
+    return ctor.Invoke(parameters) as dynamic;
   }
 }
 
@@ -18,7 +18,7 @@ internal class Manifest
   {
     var streamDeckAttribute = assembly.GetCustomAttribute<StreamDeckManifestAttribute>();
     var types = assembly.GetTypes().Where(t => t.IsClass && t.IsSubclassOf(typeof(StreamDeckAction)));
-    this.Actions = new List<StreamDeckAction>();
+    this.Actions = new List<dynamic>();
     foreach (var type in types)
     {
       var action = type.GetInstance();
@@ -95,7 +95,7 @@ internal class Manifest
     return platforms;
   }
 
-  public ICollection<StreamDeckAction> Actions { get; private set; }
+  public ICollection<dynamic> Actions { get; private set; }
   public string Author { get; private set; }
   public string Category { get; private set; }
   public string CategoryIcon { get; private set; }

--- a/Parithon.StreamDeck.SDK.MSBuild.Tool/Program.cs
+++ b/Parithon.StreamDeck.SDK.MSBuild.Tool/Program.cs
@@ -22,7 +22,8 @@ foreach (var action in manifest.Actions)
 
   for (int i = 0; i < action.States.Count; i++)
   {
-    var state = action.States.Skip(i).FirstOrDefault();
+    var states = action.States as IEnumerable<dynamic>;
+    var state = states.Skip(i).FirstOrDefault();
     if (state == null) break;
 
     var stateIconPath = Path.Combine(Path.GetDirectoryName(buildAssembly.Location), $"{state.Image}.png");


### PR DESCRIPTION
Updated the manifest generation process to use 'dynamic' instead of 'StreamDeckAction' while invoking the reflection types.
Additionally updated the manifest checks to work with 'dynamic' instead of 'StreamDeckAction'

Resolves: #15